### PR TITLE
move apartments with same coordinates 5m away from each other

### DIFF
--- a/app/api/update_houses.php
+++ b/app/api/update_houses.php
@@ -151,15 +151,15 @@ function fetch_hemnet_houses(){
 
         // Check if the coordinates already exist in the $houses array
         $lat_lng_key = $this_house['lat'] . ',' . $this_house['lng'];
-        if (isset($all_lat_lng[$lat_lng_key])) {
+        while (isset($all_lat_lng[$lat_lng_key])) {
             // Coordinates already exist, adjust them slightly to move the house 5 meters away
 
             $newCoordinates = moveHouseCoordinates($this_house['lat'], $this_house['lng'], 5); // 5 meters
 
             $this_house['lat'] = $newCoordinates['lat'];
             $this_house['lng'] = $newCoordinates['lng'];
+            $lat_lng_key = $this_house['lat'] . ',' . $this_house['lng'];  // Update key with possibly new coordinates
         }
-        $lat_lng_key = $this_house['lat'] . ',' . $this_house['lng'];  // Update key with possibly new coordinates
         $all_lat_lng[$lat_lng_key] = $this_house;
 
 

--- a/app/api/update_houses.php
+++ b/app/api/update_houses.php
@@ -116,6 +116,8 @@ function fetch_hemnet_houses(){
       // Parse the response
       $results_json = @json_decode($result_raw, true);
       $num_results = $results_json['data']['searchListings']['total'];
+      
+      $all_lat_lng = [];
 
       foreach($results_json['data']['searchListings']['listings'] as $listing){
 
@@ -146,6 +148,21 @@ function fetch_hemnet_houses(){
         // Array keys two-deep
         $this_house['lat'] = $listing['coordinates']['lat'];
         $this_house['lng'] = $listing['coordinates']['long'];
+
+        // Check if the coordinates already exist in the $houses array
+        $lat_lng_key = $this_house['lat'] . ',' . $this_house['lng'];
+        if (isset($all_lat_lng[$lat_lng_key])) {
+            // Coordinates already exist, adjust them slightly to move the house 5 meters away
+
+            $newCoordinates = moveHouseCoordinates($this_house['lat'], $this_house['lng'], 5); // 5 meters
+
+            $this_house['lat'] = $newCoordinates['lat'];
+            $this_house['lng'] = $newCoordinates['lng'];
+        }
+        $lat_lng_key = $this_house['lat'] . ',' . $this_house['lng'];  // Update key with possibly new coordinates
+        $all_lat_lng[$lat_lng_key] = $this_house;
+
+
         $this_house['askingPrice'] = 0;
         if(array_key_exists('askingPrice', $listing) && !is_null($listing['askingPrice'])) $this_house['askingPrice'] = $listing['askingPrice']['amount'];
         $this_house['runningCosts'] = 0;
@@ -201,7 +218,27 @@ function fetch_hemnet_houses(){
   return array("status"=>"success", "msg" => "Found ".count($houses)." houses");
 }
 
+/**
+ * Function to move coordinates a specified distance in meters
+ * @param float $lat Latitude of the original location
+ * @param float $lng Longitude of the original location
+ * @param float $distance Distance in meters to move
+ * @return array New latitude and longitude
+ */
+function moveHouseCoordinates($lat, $lng, $distance) {
+  // Earth’s radius, sphere
+  $earthRadius = 6378137; // Radius in meters
 
+  // Coordinate offsets in radians
+  $dLat = $distance / $earthRadius;
+  $dLng = $distance / ($earthRadius * cos(pi() * $lat / 180));
+
+  // OffsetPosition, decimal degrees
+  $newLat = $lat + ($dLat * 180 / pi());
+  $newLng = $lng + ($dLng * 180 / pi());
+
+  return ['lat' => $newLat, 'lng' => $newLng];
+}
 
 /////////
 // CALLED DIRECTLY - API usage


### PR DESCRIPTION
Thank you for creating and maintaining such a great project! I started using it today and noticed an issue when retrieving data from Hemnet. Some homes in the same building have identical latitude and longitude coordinates, which makes it difficult for users to distinguish between them on the map.

To address this, I have implemented a small adjustment that slightly offsets the coordinates of homes located in the same building by 5 meters. This change ensures that users can clearly see all available options in the same building. I hope this enhancement improves the user experience.