### PR TITLE
add filter by tags / add floor to storeys/ add show upcoming visitings

### DIFF
--- a/app/api/houses.php
+++ b/app/api/houses.php
@@ -169,6 +169,19 @@ function get_houses($postdata){
       }
     }
 
+    if(isset($postdata['tags'])){
+      $hasAllTags = true;
+      foreach($postdata['tags'] as $tag_id){
+        if($house_results[$house_id]['tags'][$tag_id] == false){
+          $hasAllTags = false;
+        }
+      }
+
+      if($hasAllTags == false){
+        $remove = true;
+      }
+    }
+
     if($remove) unset($house_results[$house_id]);
   }
 

--- a/app/api/update_houses.php
+++ b/app/api/update_houses.php
@@ -39,6 +39,8 @@ function fetch_hemnet_houses(){
   $num_keys = [
     'livingArea',
     'landArea',
+    'floor',
+    'storeys',
     'supplementalArea',
     'daysOnHemnet',
     'numberOfRooms'
@@ -96,6 +98,7 @@ function fetch_hemnet_houses(){
       curl_setopt($curl, CURLOPT_POST, true);
       curl_setopt($curl, CURLOPT_POSTFIELDS, json_encode($postdata));
 
+      error_log("My variable value: " . json_encode($postdata));;
       // Fetch cURL API response
       $result_raw = curl_exec($curl);
       $status = curl_getinfo($curl, CURLINFO_HTTP_CODE);
@@ -283,6 +286,8 @@ function graphql_iOSSearchQuery(){
           }
 
           livingArea
+          floor
+          storeys
           landArea
           supplementalArea
           daysOnHemnet

--- a/app/app.js
+++ b/app/app.js
@@ -46,6 +46,7 @@ app.controller("hemnetCommuterController", ['$scope', '$compile', '$http', '$tim
     open_house_before: '',
     open_house_after: '',
     hide_failed_commutes: [],
+    tags: []
   }
 
   $scope.stats = {
@@ -451,6 +452,9 @@ app.controller("hemnetCommuterController", ['$scope', '$compile', '$http', '$tim
 
     // Build filters POST data
     var postdata = {};
+    if($scope.filters.tags.length > 0){
+      postdata.tags = $scope.filters.tags;
+    }
     if ($scope.filters.min_combined_rating_score != ($scope.num_users * -1).toString()) {
       postdata.min_combined_rating_score = $scope.filters.min_combined_rating_score;
     }
@@ -949,6 +953,22 @@ app.controller("hemnetCommuterController", ['$scope', '$compile', '$http', '$tim
       $scope.active_house.tags[tag_id] = selected;
     });
   }
+  // add tag on filter
+  $scope.toggle_tag_filter = function (tag_id) {
+    // Check if the tag_id exists in the filters.tags array
+    if ($scope.filters.tags.includes(tag_id)) {
+      // If it exists, remove it
+      const index = $scope.filters.tags.indexOf(tag_id);
+      if (index > -1) {
+        $scope.filters.tags.splice(index, 1);
+      }
+    } else {
+      // If it does not exist, add it
+      $scope.filters.tags.push(tag_id);
+    }
+
+    $scope.update_results();
+  };
 
   // Add tag button clicked
   $scope.add_tag = function () {

--- a/app/app.js
+++ b/app/app.js
@@ -8,7 +8,7 @@
  */
 
 var app = angular.module("hemnetCommuterApp", ['ui-leaflet', 'ngCookies', 'ngAnimate', 'ngTouch', 'ui.bootstrap']);
-app.controller("hemnetCommuterController", ['$scope', '$compile', '$http', '$timeout', '$cookies', 'leafletData', function ($scope, $compile, $http, $timeout, $cookies, leafletData) {
+app.controller("hemnetCommuterController", ['$scope', '$location', '$compile', '$http', '$timeout', '$cookies', 'leafletData', function ($scope, $location, $compile, $http, $timeout, $cookies, leafletData) {
 
   // Put some common functions onto the $scope
   $scope.isArray = angular.isArray;
@@ -601,6 +601,19 @@ app.controller("hemnetCommuterController", ['$scope', '$compile', '$http', '$tim
         }
       }, 1000);
 
+
+      // Check for `active_house_id` in URL query parameters on page load
+      const active_house_id = $location.search().active_house_id;
+
+      if (active_house_id) {
+        // If `active_house_id` exists, simulate a marker click
+
+        // Assuming we have a method to programmatically trigger the event
+        $timeout(function () {
+          $scope.$broadcast('leafletDirectiveMarker.click', { model: { id: active_house_id } });
+        }, 200);
+      }
+
     });
   };
 
@@ -780,12 +793,14 @@ app.controller("hemnetCommuterController", ['$scope', '$compile', '$http', '$tim
   // Leaflet marker clicked
   $scope.$on('leafletDirectiveMarker.click', function (event, args) {
     // Get house details
+    debugger
     if (args.model.id !== undefined) {
       // Clear any active error message
       $scope.error_msg = false;
 
       $scope.active_id = args.model.id;
       $scope.active_house = $scope.results[$scope.active_id];
+      $location.search('active_house_id', $scope.active_id);
       $scope.active_house.description_translatedText = '';
       $scope.active_house.carousel = [];
       $scope.carousel_idx = 0;
@@ -906,6 +921,7 @@ app.controller("hemnetCommuterController", ['$scope', '$compile', '$http', '$tim
       });
     }
   });
+  
 
   // Ratings button clicked
   $scope.save_rating = function (r_user_id, rating) {

--- a/app/app.js
+++ b/app/app.js
@@ -222,7 +222,7 @@ app.controller("hemnetCommuterController", ['$scope', '$compile', '$http', '$tim
   $scope.hemnet_results_updating = false;
   $scope.hemnet_results_update_btn_text = 'Update';
   $scope.translate_target_language = '';
-  $scope.translate_description = true;
+  $scope.translate_description = false;
 
   // Build custom leaflet buttons for map settings
   L.Control.HncBtn = L.Control.extend({

--- a/app/app.js
+++ b/app/app.js
@@ -858,7 +858,7 @@ app.controller("hemnetCommuterController", ['$scope', '$location', '$compile', '
 
       $scope.active_id = args.model.id;
       $scope.active_house = $scope.results[$scope.active_id];
-      $location.search('active_house_id', $scope.active_id);
+      // $location.search('active_house_id', $scope.active_id);
       $scope.active_house.description_translatedText = '';
       $scope.active_house.carousel = [];
       $scope.carousel_idx = 0;

--- a/app/index.html
+++ b/app/index.html
@@ -334,6 +334,20 @@
               <label class="form-check-label" for="rating_not_set_{{user_id}}">Not set</label>
             </td>
           </tr>
+          <tr>
+            <th>has tag: </th>
+            <td class="px-2" ng-repeat="(tag_id, _) in tags">
+              <button 
+                class="btn btn-outline-secondary p-1 mr-2 mb-2" 
+                style="font-size: .7rem;"
+                ng-click="toggle_tag_filter(tag_id)" 
+                ng-class="{'active': filters.tags.includes(tag_id)}"
+              >
+                  {{tags[tag_id]}}
+                </button>
+            </td>
+          </tr>
+          
         </table>
 
         <h6>Commute time thresholds</h6>

--- a/app/index.html
+++ b/app/index.html
@@ -181,6 +181,10 @@
               <th>Rooms:</th>
               <td>{{ active_house.numberOfRooms }}</td>
             </tr>
+            <tr>
+              <th>Floor:</th>
+              <td>{{ active_house.floor }} of {{ active_house.storeys }}</td>
+            </tr>
             <tr ng-show="active_house.runningCosts > 0">
               <th>Operating cost:</th>
               <td>{{ active_house.runningCosts | number:0 }} kr/year <small>( <span ng-bind="active_house.runningCosts / 12 | number:0"></span> kr/month)</small></td>

--- a/app/index.html
+++ b/app/index.html
@@ -636,6 +636,7 @@
             </div>
             <div class="col-10 d-flex justify-content-around">
               <div class="row flex-column">
+                <h6>{{ visiting.title }}</h6>
                 <p>
                   Next Visiting:
                   <span class="mb-0 ml-2">
@@ -651,11 +652,11 @@
                 </p>
               </div>
               
-              
-              <h6>{{ visiting.address }}</h6>
               <!-- <div class="row"> -->
                 <div class="col-4">
+                  
                   <img ng-src="{{ visiting.image_url }}" class="w-100 mb-2">
+                  
                 </div>
               <!-- </div> -->
             </div>

--- a/app/index.html
+++ b/app/index.html
@@ -100,9 +100,9 @@
             </span>
           </h3>
           <h4 ng-show="active_house.isNewConstruction == 1 || active_house.isUpcoming == 1 || active_house.isBiddingOngoing == 1" class="clearfix">
-            <span ng-show="active_house.isNewConstruction == 1" class="badge badge-light border text-secondary"><i class="fa fa-certificate mr-2" aria-hidden="true"></i>Nyproduktion</span>
+            <span ng-show="active_house.isNewConstruction == 1" class="badge badge-light border text-secondary"><i class="fa fa-certificate mr-2" aria-hidden="true"></i>New production</span>
             <span ng-show="active_house.isUpcoming == 1" class="badge badge-success"><i class="fa fa-bolt mr-2" aria-hidden="true"></i>Kommande</span>
-            <span ng-show="active_house.isBiddingOngoing == 1" class="badge badge-info" style="background-color: #67458c;"><i class="fa fa-gavel mr-2" aria-hidden="true"></i> Budgivning pågår</span>
+            <span ng-show="active_house.isBiddingOngoing == 1" class="badge badge-info" style="background-color: #67458c;"><i class="fa fa-gavel mr-2" aria-hidden="true"></i> Bidding is ongoing</span>
           </h4>
 
           <!-- Buttons - first row -->
@@ -114,7 +114,7 @@
             </div>
             <div class="col-4">
               <a ng-href="{{active_house.listingBrokerUrl}}" ng-class="{'disabled': !active_house.listingBrokerUrl}" target="_blank" class="btn btn-block btn-success" style="white-space: nowrap; overflow: hidden;">
-                <i class="fa fa-bookmark mr-2" id="commute_icon"></i> Mäklare
+                <i class="fa fa-bookmark mr-2" id="commute_icon"></i> Broker
               </a>
             </div>
             <div class="col-4">
@@ -137,7 +137,7 @@
               <small style="white-space: nowrap;"><i class="fa fa-apple mr-1"></i> Maps</a></small>
             </div>
             <div class="col-3"><a ng-href="api/link_lantmateriet.php?lat={{active_house.lat}}&lng={{active_house.lng}}&z=16" target="_blank" class="btn btn-sm btn-block btn-outline-danger" style="overflow:hidden;">
-              <small style="white-space: nowrap;"><i class="fa fa-compass mr-1"></i> Lantmäteriet</a></small>
+              <small style="white-space: nowrap;"><i class="fa fa-compass mr-1"></i> The land surveyor</a></small>
             </div>
           </div>
 
@@ -174,7 +174,7 @@
               </td>
             </tr>
             <tr>
-              <th>Tomt:</th>
+              <th>Plot:</th>
               <td>{{ active_house.formattedLandArea }}</td>
             </tr>
             <tr>
@@ -182,7 +182,7 @@
               <td>{{ active_house.numberOfRooms }}</td>
             </tr>
             <tr ng-show="active_house.runningCosts > 0">
-              <th>Driftkostnad:</th>
+              <th>Operating cost:</th>
               <td>{{ active_house.runningCosts | number:0 }} kr/year <small>( <span ng-bind="active_house.runningCosts / 12 | number:0"></span> kr/month)</small></td>
             </tr>
             <tr ng-repeat="(commute_id, commute) in commute_locations">

--- a/app/index.html
+++ b/app/index.html
@@ -215,7 +215,7 @@
             <button type="button" ng-class="{'active': translate_description}" ng-click="translate_description = true" class="btn btn-light">{{ translate_target_language }}</button>
           </div>
           <p ng-show="!translate_description" class="small text-muted" style="white-space: pre-wrap;">{{ active_house.description }}</p>
-          <p ng-show="translate_description" class="small text-muted" style="white-space: pre-wrap;">{{ active_house.description_translatedText }}</p>
+          <p ng-show="translate_description" class="small text-muted" style="white-space: pre-wrap;">{{ active_house.description_translatedText || active_house.description }}</p>
 
           <div class="row my-5 house_ratings">
             <div ng-repeat="(user_id, user_name) in users" class="col-6">

--- a/app/index.html
+++ b/app/index.html
@@ -608,6 +608,60 @@
         </div>
 
       </div>
+
+      <!-- Visting -->
+      <div ng-show="sidebar == 'visiting'" class="pt-3">
+        <h3 class="text-success"><i class="fa fa-street-view mr-1"></i> Visting</h3>
+        <!-- <div class="row border-bottom pb-2 mb-2">
+          <div class="col-6">
+            <select class="custom-select" ng-model="recent_ratings_filter_user" ng-change="update_recent_ratings()">
+              <option value="">Everyone</option>
+              <option ng-repeat="(user_id, user_name) in users" value="{{ user_id }}">{{ user_name }}</option>
+            </select>
+          </div>
+          <div class="col-6">
+            <select class="custom-select" ng-model="recent_ratings_filter_type" ng-change="update_recent_ratings()">
+              <option value="">All rating types</option>
+              <option value="yes">Yes</option>
+              <option value="maybe">Maybe</option>
+              <option value="no">No</option>
+            </select>
+          </div>
+        </div> -->
+        <div ng-repeat="visiting in upcoming_visitings_houses" class="border-bottom mb-2" ng-click="simulateClickOnMarker(visiting.id)">
+          <div class="row">
+            <div class="col-2 text-center d-flex justify-content-center align-items-center"
+            >
+              <i ng-class="getIconClasses(visiting.marker.icon)" ng-style="getIconStyles(visiting.marker.icon)"></i>
+            </div>
+            <div class="col-10 d-flex justify-content-around">
+              <div class="row flex-column">
+                <p>
+                  Next Visiting:
+                  <span class="mb-0 ml-2">
+                    {{ visiting.nextOpenHouse * 1000.00 | date: 'EEE d MMM, HH:mm' }}
+                  </span>
+                </p>
+                <p>
+                  All visitings: 
+                  <span
+                    ng-repeat="open_house in visiting.upcomingOpenHouses track by $index" class="mb-0 ml-2">
+                    {{ open_house * 1000.00 | date: 'EEE d MMM, HH:mm' }}
+                  </span>
+                </p>
+              </div>
+              
+              
+              <h6>{{ visiting.address }}</h6>
+              <!-- <div class="row"> -->
+                <div class="col-4">
+                  <img ng-src="{{ visiting.image_url }}" class="w-100 mb-2">
+                </div>
+              <!-- </div> -->
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
   </div>
   <footer ng-show="show_footer" class="d-flex">

--- a/hemnet_commuter.sql
+++ b/hemnet_commuter.sql
@@ -83,6 +83,8 @@ CREATE TABLE `houses` (
   `isForeclosure` int(1) NOT NULL DEFAULT '0',
   `isBiddingOngoing` int(1) NOT NULL DEFAULT '0',
   `livingArea` double NOT NULL,
+  `floor` double NOT NULL,
+  `storeys` double NOT NULL DEFAULT '0',
   `landArea` double NOT NULL,
   `supplementalArea` double NOT NULL,
   `daysOnHemnet` int(30) NOT NULL,


### PR DESCRIPTION
I have implemented several new features:

1. Users can now filter properties based on the tags that have been added.
2. Property information now includes details about the floor and the number of storeys.
3. Users can view a sorted list of upcoming property viewings directly on the map. When a filter is applied, the list will only display viewings for properties that match the selected criteria.
4. Previously, the default language was set to English (EN). If the Google Translate API wasn't configured, no descriptions would appear. I have now changed the default language to Swedish (SV), ensuring descriptions are displayed even when there is no translated version available.